### PR TITLE
🔧 chore: add Renovate release cooldown

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,6 +2,7 @@
   "extends": ["config:base", "schedule:weekly", "group:allNonMajor"],
   "labels": ["dependencies"],
   "pin": false,
+  "minimumReleaseAge": "1 day",
   "commitMessagePrefix": "⬆️ deps: ",
   "dependencyDashboardTitle": "☑️ Dependency Dashboard",
   "packageRules": [


### PR DESCRIPTION
## Summary
- Set Renovate `minimumReleaseAge` to `1 day` to align with pnpm 11 default package cooldown.
- Prevent Renovate PRs from selecting releases that CI pnpm supply-chain policy still rejects.

## Root Cause
Renovate could update lockfiles to packages published less than one day ago, while pnpm 11 rejects those entries during install verification.

## Validation
- `jq empty default.json`
- `renovate@43.202.1 renovate-config-validator default.json`